### PR TITLE
Decoder write fixes

### DIFF
--- a/src/lib.zig
+++ b/src/lib.zig
@@ -150,12 +150,13 @@ const Decoder = struct {
 
         if (frame.*.header.channels == 3) {
             for (0..frame.*.header.blocksize) |i| {
-                const center = @divTrunc(buffer[2][i], 2);
-                const left = (buffer[0][i]) + center;
-                const right = (buffer[1][i]) + center;
+                const left = (buffer[0][i]);
+                const right = (buffer[1][i]);
+                const center = (buffer[2][i]);
                 data.samples[data.sample_index] = left;
                 data.samples[data.sample_index + 1] = right;
-                data.sample_index += 2;
+                data.samples[data.sample_index + 2] = center;
+                data.sample_index += 3;
             }
         } else {
             for (0..frame.*.header.blocksize) |i| {
@@ -176,10 +177,7 @@ const Decoder = struct {
         user_data: ?*anyopaque,
     ) callconv(.C) void {
         const data = @as(*Decoder, @ptrCast(@alignCast(user_data)));
-        data.channels = switch (metadata.*.data.stream_info.channels) {
-            3 => 2, // We'll drop the center channel and mix it with Left and Right channels
-            else => @intCast(metadata.*.data.stream_info.channels),
-        };
+        data.channels = @intCast(metadata.*.data.stream_info.channels);
         data.sample_rate = @intCast(metadata.*.data.stream_info.sample_rate);
         data.bits_per_sample = @intCast(metadata.*.data.stream_info.bits_per_sample);
         data.total_samples = @intCast(metadata.*.data.stream_info.total_samples);

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -148,12 +148,11 @@ const Decoder = struct {
             }
         }
 
-        const shift_amount: u5 = @intCast(32 - data.bits_per_sample);
         if (frame.*.header.channels == 3) {
             for (0..frame.*.header.blocksize) |i| {
-                const center = @divExact(buffer[2][i] << shift_amount, 2);
-                const left = (buffer[0][i] << shift_amount) + center;
-                const right = (buffer[1][i] << shift_amount) + center;
+                const center = @divTrunc(buffer[2][i], 2);
+                const left = (buffer[0][i]) + center;
+                const right = (buffer[1][i]) + center;
                 data.samples[data.sample_index] = left;
                 data.samples[data.sample_index + 1] = right;
                 data.sample_index += 2;
@@ -162,7 +161,7 @@ const Decoder = struct {
             for (0..frame.*.header.blocksize) |i| {
                 for (0..data.channels) |ch| {
                     const sample = buffer[ch][i];
-                    data.samples[data.sample_index] = sample << shift_amount;
+                    data.samples[data.sample_index] = sample;
                     data.sample_index += 1;
                 }
             }


### PR DESCRIPTION
The first commit removes the bit shift being performed on samples in the decoder write callback. The FLAC decoder library already ensures the samples are in the right range for the bit depth. After this change, `@divExact` produced a remainder, so that was changed to `@divTruncate`, but that is possibly moot...

I wrote a small Zig program to decode a 16-bit FLAC and count how many samples exceeded the max range for 16-bit numbers. It also writes all the samples to a text file:

```console
> zig build demo
bad samples: 6217730
Decoded FLAC: Channels: 2, Sample Rate: 44100, Bits per Sample: 16, Samples: 6311566
```

As a reference, I wrote the same program in Go so I can diff the samples in the text file:

```console
> diff decoded_samples.zig.txt decoded_samples.go.txt  -q
Files decoded_samples.txt and decoded_samples.go.txt differ
```

After removing the bit shift, there are no more bad samples and the samples are identical to the Go program:

```console
> zig build demo
bad samples: 0
Decoded FLAC: Channels: 2, Sample Rate: 44100, Bits per Sample: 16, Samples: 6311566
> diff decoded_samples.zig.txt decoded_samples.go.txt -q
```

The second commit adds support for 3 channels because...it was right there and it works :) `center.flac` now passes the sanity checks I demonstrated above.

If needed, I can provided the code I used to check my work.

---
- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.